### PR TITLE
Handle case where push/pull msgs get stuck

### DIFF
--- a/lib/broker/pushpull.js
+++ b/lib/broker/pushpull.js
@@ -25,11 +25,10 @@ module.exports = {
       }, function (err, results) {
         //send the results as a multipart message
         // - err, r1, r2, ... rN
-        router.send([identity, empty, utils.serialize(err)].concat(results.map(utils.serialize)));
+        router.send([identity, empty, utils.serialize(err)].concat(results));
       });
     });
     
-
     pull.on('message', function (id, err, result) {
       id = id.toString();
       var task = tasks[id];
@@ -38,7 +37,7 @@ module.exports = {
 
       var cb = task.cb;
       delete tasks[id];
-      return cb && cb(utils.deserialize(err), utils.deserialize(result));
+      return cb && cb(utils.deserialize(err), result);
     });
 
     pull.on('error', error.handle);
@@ -48,6 +47,14 @@ module.exports = {
     router.bindSync('tcp://*:5003');
     push.bindSync('tcp://*:5557');
     pull.bindSync('tcp://*:5558');
+
+    setInterval(function () {
+      //HACK: THIS IS WRONG
+      //      but seems to get things working
+      pull._flush();
+      push._flush();
+      router._flush();
+    }, 1000);
 
     return {
       stop: function () {

--- a/lib/client/pushpull.js
+++ b/lib/client/pushpull.js
@@ -28,15 +28,9 @@ module.exports = {
 
     pull.on('message', function (id, task) {
       if (func) {
-        process.nextTick(function () {
-          task = utils.deserialize(task);
-          func(task, function (err, result) {
-            push.send([
-              id,
-              utils.serialize(err),
-              utils.serialize(result)
-            ]);
-          });
+        task = utils.deserialize(task);
+        func(task, function (err, result) {
+          push.send([id, utils.serialize(err), utils.serialize(result)]);
         });
       }
       else {

--- a/lib/client/reqrep.js
+++ b/lib/client/reqrep.js
@@ -27,18 +27,16 @@ module.exports = {
       var task = utils.deserialize(buff);
 
       if (task === 'hello?') {
-        return rep.send([null, utils.serialize('hello!')]);
+        return rep.send([null, '"hello!"']);
       }
 
       //HACK: we should handle this better
       if (func) {
-        process.nextTick(function () {
-          func(task, function (err, result) {
-            rep.send([
-              utils.serialize(err),
-              utils.serialize(result)
-            ]);
-          });
+        func(task, function (err, result) {
+          rep.send([
+            utils.serialize(err),
+            utils.serialize(result)
+          ]);
         });
       }
       else {
@@ -52,7 +50,7 @@ module.exports = {
       rep.connect('tcp://' + ip + ':5001');
     }
 
-    req.send(JSON.stringify('hello?'));
+    req.send('"hello?"');
   },
   close: function () {
     req.close();


### PR DESCRIPTION
Under load there was a case where we would notice messages being stuck somewhere in zmq land. Nothing would process until another message was sent and zmq would wake up and send the messages.

I think the real problem is hitting the HWM limit in our queues (see https://github.com/JustinTulloss/zeromq.node/issues/203).  A workaround proposed there is to manually flush the sockets on a timer.
- [x] manually flush on a timer
- [x] do a lot of testing
- [x] make sure everything still kinda works
